### PR TITLE
Update RSKPlaceholderTextView dependency

### DIFF
--- a/RSKGrowingTextView.podspec
+++ b/RSKGrowingTextView.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.source_files  = 'RSKGrowingTextView/*.{h,swift}'
   s.requires_arc  = true
-  s.dependency 'RSKPlaceholderTextView', '5.0.0'
+  s.dependency 'RSKPlaceholderTextView', '~> 5.0.1'
 end


### PR DESCRIPTION
This PR simply updates the podspec dependency to pick up the latest version of RSKPlaceholderTextView instead of being locked at 5.0.0.

In our project we depend on the `RSKGrowingTextView` pod but also use `RSKPlaceholderTextView`. Since the podspec is locked on 5.0.0, we can't use the latest placeholder text view 5.0.1. This PR should address that.